### PR TITLE
Use default UniqueId.

### DIFF
--- a/pyOCD/pyDAPAccess/dap_access_usb.py
+++ b/pyOCD/pyDAPAccess/dap_access_usb.py
@@ -42,12 +42,7 @@ def _get_interfaces():
 
 def _get_unique_id(interface):
     """Get the unique id from an interface"""
-    interface.write([0x80])
-    raw_id = bytearray(interface.read())
-    id_start = 2
-    id_size = raw_id[1]
-    unique_id = str(raw_id[id_start:id_start + id_size])
-    return unique_id
+    return interface.getSerialNumber()
 
 
 class _Transfer(object):


### PR DESCRIPTION
…ust get the unique_id in local memory we can't detect target realtime with this function."

This reverts commit 8485c2bcc2afca9fa5907aceeaf12ba5140c7eab.
